### PR TITLE
feat: support Laravel 12 and 13 (illuminate/support ^12|^13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^8.1 || ^8.2",
-        "illuminate/support": "^9|^10|^11"
+        "illuminate/support": "^9|^10|^11|^12"
     },
     "license": "Proprietary",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^8.1 || ^8.2",
-        "illuminate/support": "^9|^10|^11|^12"
+        "illuminate/support": "^9|^10|^11|^12|^13"
     },
     "license": "Proprietary",
     "autoload": {


### PR DESCRIPTION
Widens `illuminate/support` to `^9|^10|^11|^12|^13` so the package installs under Laravel 12 **and** 13.

Tags:
- `1.2.0` — adds Laravel 12 support (required by the aloware/api-core L11→12 upgrade, `composer require aloware/auditable:^1.2`)
- `1.3.0` — adds Laravel 13 support (forward-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)